### PR TITLE
fix: cryptic error message in Node.of()

### DIFF
--- a/lib/construct.ts
+++ b/lib/construct.ts
@@ -28,7 +28,7 @@ export class Node {
   public static of(construct: IConstruct): Node {
     const node = (construct as any)[CONSTRUCT_NODE_PROPERTY_SYMBOL] as Node;
     if (!node) {
-      throw new Error(`construct does not have an associated node`);
+      throw new Error(`construct does not have an associated node. All constructs must extend the "Construct" base class`);
     }
 
     return node;


### PR DESCRIPTION
When `Node.of()` is called with an object that does not really extend `Construct`, we can't find the associated construct node. This change improves the error message to provide some hint for why this could happen.

Fixes #16
Related aws/aws-cdk#6885


*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
