### PR TITLE
fix: constructs created by an Aspect are not prepared

### DIFF
--- a/lib/construct.ts
+++ b/lib/construct.ts
@@ -428,16 +428,14 @@ export class Node {
    * Invokes "prepare" on all constructs (depth-first, post-order) in the tree under `node`.
    */
   public prepare() {
-    let constructs = this.findAll(ConstructOrder.PREORDER);
-
     // Aspects are applied root to leaf
-    for (const construct of constructs) {
+    for (const construct of this.findAll(ConstructOrder.PREORDER)) {
       Node.of(construct).invokeAspects();
     }
 
-    // Since constrcuts can be added to the tree when invoking an Aspect, recreate the constructs list
-    constructs = this.findAll(ConstructOrder.POSTORDER);
-    for (const construct of constructs) {
+    // since constrcuts can be added to the tree when invoking an Aspect, call findAll() to recreate the list
+    // prepare is called leaves to root, PREORDER.reverse() for backward compatability
+    for (const construct of this.findAll(ConstructOrder.PREORDER).reverse()) {
       if (construct instanceof Construct) {
         (construct as any).onPrepare(); // "as any" is needed because we want to keep "prepare" protected
       }

--- a/lib/construct.ts
+++ b/lib/construct.ts
@@ -428,15 +428,16 @@ export class Node {
    * Invokes "prepare" on all constructs (depth-first, post-order) in the tree under `node`.
    */
   public prepare() {
-    const constructs = this.findAll(ConstructOrder.PREORDER);
+    let constructs = this.findAll(ConstructOrder.PREORDER);
 
     // Aspects are applied root to leaf
     for (const construct of constructs) {
       Node.of(construct).invokeAspects();
     }
 
-    // Use .reverse() to achieve post-order traversal
-    for (const construct of constructs.reverse()) {
+    // Since constrcuts can be added to the tree when invoking an Aspect, recreate the constructs list
+    constructs = this.findAll(ConstructOrder.POSTORDER);
+    for (const construct of constructs) {
       if (construct instanceof Construct) {
         (construct as any).onPrepare(); // "as any" is needed because we want to keep "prepare" protected
       }

--- a/lib/construct.ts
+++ b/lib/construct.ts
@@ -433,8 +433,8 @@ export class Node {
       Node.of(construct).invokeAspects();
     }
 
-    // since constrcuts can be added to the tree when invoking an Aspect, call findAll() to recreate the list
-    // prepare is called leaves to root, PREORDER.reverse() for backward compatability
+    // since constructs can be added to the tree during invokeAspects, call findAll() to recreate the list.
+    // use PREORDER.reverse() for backward compatability
     for (const construct of this.findAll(ConstructOrder.PREORDER).reverse()) {
       if (construct instanceof Construct) {
         (construct as any).onPrepare(); // "as any" is needed because we want to keep "prepare" protected

--- a/test/test.construct.ts
+++ b/test/test.construct.ts
@@ -482,7 +482,7 @@ export = {
     'constructs created in an Aspect are prepared'(test: Test) {
       const root = new Root();
       const construct = new Construct(root, 'Resource');
-      Node.of(construct).applyAspect(new MyBeautifulAspect(construct));
+      Node.of(construct).applyAspect(new AddConstructAspect(construct));
       Node.of(root).prepare();
       // THEN
       const addedConstruct = Node.of(root).findAll(ConstructOrder.PREORDER)
@@ -530,7 +530,7 @@ class MyAlmostBeautifulConstruct extends Construct {
   }
 }
 
-class MyBeautifulAspect implements IAspect {
+class AddConstructAspect implements IAspect {
   constructor(private readonly scope: Construct) {}
   
   visit(node: IConstruct): void {

--- a/test/test.construct.ts
+++ b/test/test.construct.ts
@@ -1,6 +1,7 @@
 import { Test } from 'nodeunit';
-import { Construct, ConstructMetadata, Node, ConstructOrder, Lazy, ValidationError } from '../lib';
+import { Construct, ConstructMetadata, Node, ConstructOrder, Lazy, ValidationError, IConstruct } from '../lib';
 import { App as Root } from './util';
+import { IAspect } from '../lib/aspect';
 
 // tslint:disable:variable-name
 // tslint:disable:max-line-length
@@ -477,7 +478,18 @@ export = {
         /Cannot determine default child for . There is both a child with id "Resource" and id "Default"/);
       test.done();
 
-    }
+    },
+    'constructs created in an Aspect are prepared'(test: Test) {
+      const root = new Root();
+      const construct = new MyBeautifulConstruct(root, 'BeautifulConstruct');
+      Node.of(construct).applyAspect(new MyBeautifulAspect(construct));
+      Node.of(root).prepare();
+      // THEN
+      const addedConstruct = Node.of(root).findAll(ConstructOrder.PREORDER)
+      .find(child => Node.of(child).id === `Almost-${Node.of(construct).id}`) as MyAlmostBeautifulConstruct;
+      test.deepEqual(addedConstruct.status, 'Beautiful');
+      test.done();
+    },
   }
 };
 
@@ -503,5 +515,25 @@ function createTree(context?: any) {
 class MyBeautifulConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
+  }
+}
+
+class MyAlmostBeautifulConstruct extends Construct {
+  public status: string = 'almostBeautiful'; 
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+  }
+
+  protected onPrepare() {
+    this.status = 'Beautiful'
+  }
+}
+
+class MyBeautifulAspect implements IAspect {
+  constructor(private readonly scope: Construct) {}
+  
+  visit(node: IConstruct): void {
+    new MyAlmostBeautifulConstruct(this.scope, `Almost-${Node.of(node).id}`);
   }
 }

--- a/test/test.construct.ts
+++ b/test/test.construct.ts
@@ -481,13 +481,13 @@ export = {
     },
     'constructs created in an Aspect are prepared'(test: Test) {
       const root = new Root();
-      const construct = new MyBeautifulConstruct(root, 'BeautifulConstruct');
+      const construct = new Construct(root, 'Resource');
       Node.of(construct).applyAspect(new MyBeautifulAspect(construct));
       Node.of(root).prepare();
       // THEN
       const addedConstruct = Node.of(root).findAll(ConstructOrder.PREORDER)
-      .find(child => Node.of(child).id === `Almost-${Node.of(construct).id}`) as MyAlmostBeautifulConstruct;
-      test.deepEqual(addedConstruct.status, 'Beautiful');
+      .find(child => Node.of(child).id === `AspectAdded-${Node.of(construct).id}`) as MyAlmostBeautifulConstruct;
+      test.deepEqual(addedConstruct.status, 'Prepared');
       test.done();
     },
   }
@@ -519,14 +519,14 @@ class MyBeautifulConstruct extends Construct {
 }
 
 class MyAlmostBeautifulConstruct extends Construct {
-  public status: string = 'almostBeautiful'; 
+  public status: string = 'PrePrepared'; 
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
   }
 
   protected onPrepare() {
-    this.status = 'Beautiful'
+    this.status = 'Prepared'
   }
 }
 
@@ -534,6 +534,6 @@ class MyBeautifulAspect implements IAspect {
   constructor(private readonly scope: Construct) {}
   
   visit(node: IConstruct): void {
-    new MyAlmostBeautifulConstruct(this.scope, `Almost-${Node.of(node).id}`);
+    new MyAlmostBeautifulConstruct(this.scope, `AspectAdded-${Node.of(node).id}`);
   }
 }


### PR DESCRIPTION
As a part of the `prepare` phase of a construct, the aspects defined on the construct and all of its children are invoked. After all of the aspects are invoked, `prepare` is called on the construct and all of its children. Since constructs can be added to the tree as a part of an aspect invoke (in `visit`) we must recreate the constructs list after invoking the aspects. 

**Tests**
* Add a unit tests
* Verified this change does not break aws-cdk tests

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
