### PR TITLE
chore: add a link.sh script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,23 @@ You can also use these more granular scripts:
 - `yarn compat`: check that APIs do not introduce breaking changes
 - `yarn lint`: run eslint and API compatibility
 
+### Using a local version of this library in a dependency
+
+If you're doing changes to this library,
+you often want to test them being used in a real dependency
+(for example, the [AWS CDK](https://github.com/aws/aws-cdk))
+to verify the changes work like expected.
+To make that easier,
+this repository includes a script in the `scripts`
+directory that overwrites the version of `constructs`
+in a dependency's `node_modules`
+with a symbolic link to the local version of `constructs`:
+
+```shell script
+cd my/project/that/uses/constructs/library
+/path/to/source/of/constructs/scripts/link.sh
+```
+
 ## Reporting Bugs/Feature Requests
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Creates a symlink under node_modules of a package consuming this library
+# that replaces the version from NPM with this local version.
+# Helpful when developing a project that depends on this library
+# (like the AWS CDK),
+# and needing to do some changes in this package -
+# you can test your changes on a real consumer of this library.
+#
+# Usage:
+#   cd my/project/that/uses/constructs/library
+#   /path/to/source/of/constructs/scripts/link.sh
+
+set -euo pipefail
+
+# we are in scripts/, so the root is one level up
+root="$(cd $(dirname $0)/.. && pwd)"
+mkdir -p node_modules # -p makes mkdir not fail if the directory already exists
+dest=node_modules/constructs
+
+echo "Linking: '${root}' to '${dest}'"
+rm -fr ${dest}
+# since root is a directory, node_modules needs to be the destination
+ln -fs ${root} node_modules


### PR DESCRIPTION
This is a script similar to `link-all.sh` from the AWS CDK project,
that allows you to use a local version of this library in a consuming package,
in order to test out your changes.

----------------

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
