### PR TITLE
fix: constructs will not be prepared due to instanceof issue

### DIFF
--- a/lib/construct.ts
+++ b/lib/construct.ts
@@ -435,9 +435,11 @@ export class Node {
 
     // since constructs can be added to the tree during invokeAspects, call findAll() to recreate the list.
     // use PREORDER.reverse() for backward compatability
-    for (const construct of this.findAll(ConstructOrder.PREORDER).reverse()) {
-      if (construct instanceof Construct) {
-        (construct as any).onPrepare(); // "as any" is needed because we want to keep "prepare" protected
+    for (const construct of this.findAll(ConstructOrder.PREORDER).reverse()) {      
+      const cn = construct as any;
+      if ('onPrepare' in cn) {
+        if (typeof(cn.onPrepare) !== 'function') { throw new Error(`expecting "onPrepare" to be a function`); }
+        cn.onPrepare();
       }
     }
   }

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -448,6 +448,43 @@ test('fails if there are both "Resource" and "Default"', () => {
   });
 });
 
+describe('construct prepare', () => {
+
+  it('created constructs are prepared', () => {
+    const root = new Root();
+    const construct01 = new MyAlmostBeautifulConstruct(root, 'Resource01');
+    const construct02 = new MyAlmostBeautifulConstruct(root, 'Resource02');
+    
+    Node.of(root).prepare();
+    // THEN
+    expect(construct01.status).toEqual('Prepared');
+    expect(construct02.status).toEqual('Prepared');    
+  });
+
+  it('only constructs with onPrepare function are prepared', () => {
+    const root = new Root();
+    const construct01 = new MyAlmostBeautifulConstruct(root, 'Resource01');
+    const construct02 = new MyMissingPrepareConstruct(root, 'Resource02');
+    
+    Node.of(root).prepare();
+    // THEN
+    expect(construct01.status).toEqual('Prepared');
+    expect(construct02.status).not.toEqual('Prepared'); 
+  })
+
+  it('only constructs with onPrepare function are prepared', () => {
+    const root = new Root();
+    const construct01 = new MyAlmostBeautifulConstruct(root, 'Resource01') as any;
+
+    // we try to force the error
+    construct01.onPrepare = undefined;
+
+    expect(() => Node.of(root).prepare())
+      .toThrow(/expecting "onPrepare" to be a function/);
+  });
+
+});
+
 function createTree(context?: any) {
   const root = new Root();
   const highChild = new Construct(root, 'HighChild');
@@ -465,6 +502,14 @@ function createTree(context?: any) {
   return {
     root, child1, child2, child1_1, child1_2, child1_1_1, child2_1
   };
+}
+
+class MyMissingPrepareConstruct extends Construct {
+  public status: string = 'PrePrepared'; 
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+  }
 }
 
 class MyBeautifulConstruct extends Construct {


### PR DESCRIPTION
## Commit Message

Use duck-typing so that `prepare` will recognize constructs without using `instanceof`m, which breaks if prototype does not match.

Fixes #32 

## End of Commit Message

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
