### PR TITLE
feat: node.relocate()

### DIFF
--- a/API.md
+++ b/API.md
@@ -322,6 +322,25 @@ prepare(): void
 
 
 
+#### relocate(rootPath)🔹 <a id="constructs-node-relocate"></a>
+
+Relocates this scope to a different root path.
+
+This will cause the `path` and
+`uniqueId` of this scope (and all children) to behave as if this construct was
+rooted at the new location.
+
+This method cannot be called after children have been added to this scope.
+
+```ts
+relocate(rootPath: string): void
+```
+
+* **rootPath** (<code>string</code>)  The new root (can also be an empty string to represent THE root).
+
+
+
+
 #### setContext(key, value) <a id="constructs-node-setcontext"></a>
 
 This can be used to set contextual values.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,65 @@
 [![NuGet version](https://badge.fury.io/nu/Constructs.svg)](https://badge.fury.io/nu/Constructs)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/software.constructs/constructs/badge.svg?style=plastic)](https://maven-badges.herokuapp.com/maven-central/software.constructs/constructs)
 
+## User Manual
+
+### Scope Relocation
+
+The path of a scope is used as a seed for all names generated within that scope
+such as logical names in the AWS CDK or `node.uniqueId`.
+
+There are use cases in which an entire construct subtree (scope) needs to be
+"relocated" to a different path. The main use case is in order to allow
+refactoring while preserving old names.
+
+> Be careful: relocating a scope may result in duplicate names. Use at your own
+> risk.
+
+To relocate a scope, use the `node.relocate(root)` method. This method can only
+be called before any children are added to the scope and it will impact the
+value of `node.path` and `node.uniqueId`.
+
+> If implementing name generation, make sure to refer to `node.path` as the root
+> of the scope's path instead of `node.scopes`.
+
+Let's say we had a scope `foo` that was originally under the `foo` path and it
+has a child called `childOfFoo`:
+
+```ts
+const foo = new Construct(root, 'foo');
+const childOfFoo = new Construct(foo, 'childOfFoo');
+expect(Node.of(foo).path).toBe('foo');
+expect(Node.of(childOfFoo).path).toBe('foo/childOfFoo');
+```
+
+Now, we want to refactor our code and hoist it under a new root, say `baz`:
+
+```ts
+const baz = new Construct(root, 'baz');
+const foo = new Construct(baz, 'foo');
+const childOfFoo = new Construct(foo, 'childOfFoo');
+
+// now the paths (andu uniqudIds) are different
+expect(Node.of(foo).path).toBe('bar/foo');
+expect(Node.of(childOfFoo).path).toBe('baz/foo/childOfFoo');
+```
+
+If we relocate `foo` to `foo`, the original paths are preserved:
+
+```ts
+const baz = new Construct(root, 'baz');
+const foo = new Construct(baz, 'foo');
+Node.of(construct).relocate('foo'); // must be done before adding children
+
+const childOfFoo = new Construct(foo, 'childOfFoo');
+
+// now the paths (andu uniqudIds) are different
+expect(Node.of(foo).path).toBe('foo');
+expect(Node.of(childOfFoo).path).toBe('foo/childOfFoo');
+```
+
+Similarly, the `uniqueId` of a construct will be derived from this path.
+
 ## Contributing
 
 This project has adopted the [Amazon Open Source Code of

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -56,6 +56,11 @@ export class Node {
   private readonly invokedAspects: IAspect[] = [];
   private _defaultChild: IConstruct | undefined;
 
+  /**
+   * An alternative root path for this scope.
+   */
+  private _relocated?: string;
+
   constructor(private readonly host: Construct, scope: IConstruct, id: string) {
     id = id || ''; // if undefined, convert to empty string
 
@@ -83,8 +88,32 @@ export class Node {
    * Components are separated by '/'.
    */
   public get path(): string {
-    const components = this.scopes.slice(1).map(c => Node.of(c).id);
-    return components.join(Node.PATH_SEP);
+    if (this._relocated !== undefined) {
+      return this._relocated;
+    }
+
+    if (!this.scope) {
+      return this.id;
+    } else {
+      return (Node.of(this.scope).path + Node.PATH_SEP + this.id).replace(/^\//, '');
+    }
+  }
+
+  /**
+   * Relocates this scope to a different root path. This will cause the `path` and
+   * `uniqueId` of this scope (and all children) to behave as if this construct was
+   * rooted at the new location.
+   *
+   * This method cannot be called after children have been added to this scope.
+   *
+   * @param rootPath The new root (can also be an empty string to represent THE root)
+   * @experimental
+   */
+  public relocate(rootPath: string) {
+    if (this.children.length > 0) {
+      throw new Error(`cannot relocate the scope "${this.path}" to "${rootPath}" after children have been added to it`);
+    }
+    this._relocated = rootPath;
   }
 
   /**
@@ -92,7 +121,7 @@ export class Node {
    * Includes all components of the tree.
    */
   public get uniqueId(): string {
-    const components = this.scopes.slice(1).map(c => Node.of(c).id);
+    const components = this.path.split(Node.PATH_SEP);
     return components.length > 0 ? makeUniqueId(components) : '';
   }
 


### PR DESCRIPTION
`node.relocate(root)` allows changing the root of a construct scope in order to influence how `node.path` and `node.uniqueId` are calculated. This can be used in refactoring scenarios in order to preserve the original names of resources within that scope.


*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
