### PR TITLE
chore: build go bindings

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -46,4 +46,8 @@ const project = new JsiiProject({
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
 });
 
+project.tryFindObjectFile('package.json').addOverride('jsii.targets.go', {
+  moduleName: 'github.com/aws/constructs-go',
+});
+
 project.synth();

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "eslint-plugin-import": "^2.20.2",
     "jest": "^26.4.2",
     "jest-junit": "^12",
-    "jsii": "^1.11.0",
-    "jsii-diff": "^1.11.0",
+    "jsii": "^1.17.1",
+    "jsii-diff": "^1.17.1",
     "jsii-docgen": "^1.3.2",
-    "jsii-pacmak": "^1.11.0",
+    "jsii-pacmak": "^1.17.1",
     "jsii-release": "^0.2.3",
     "json-schema": "^0.2.5",
     "projen": "^0.15.9",
@@ -123,6 +123,9 @@
       "dotnet": {
         "namespace": "Constructs",
         "packageId": "Constructs"
+      },
+      "go": {
+        "moduleName": "github.com/aws/constructs-go"
       }
     },
     "tsc": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3614,7 +3614,7 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsii-diff@^1.11.0:
+jsii-diff@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/jsii-diff/-/jsii-diff-1.17.1.tgz#ad5fab80ce6cef09ef17f2012cfb0fc672b58750"
   integrity sha512-1xi3z/xWLqyz32B+pqbVkJsHTe+8FpzuqOG4eQ1hIfi368IUEcrHhthhleZdQnkbkg7Z9TqXiW6RiRCKcE47Zw==
@@ -3636,7 +3636,7 @@ jsii-docgen@^1.3.2:
     jsii-reflect "^1.16.0"
     yargs "^16.2.0"
 
-jsii-pacmak@^1.11.0:
+jsii-pacmak@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-1.17.1.tgz#16777cfd7485bad2ec071f8267300c61193ec3a0"
   integrity sha512-9vxNObAkAqzRaU5qcFzJmi6gYQ6fllOqgGjqaEWdWlcMFx2XzgSOtALrksi/YRLwuZtPCZrUnSEV5SeralSkUg==
@@ -3682,7 +3682,7 @@ jsii-rosetta@^1.17.1:
     xmldom "^0.4.0"
     yargs "^16.2.0"
 
-jsii@^1.11.0:
+jsii@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/jsii/-/jsii-1.17.1.tgz#1c8cdece2354a87155e4ea989690c9e1ae8af049"
   integrity sha512-Hx2oJjD7mXWD73A8yRkNzE9QDkfn+oDNUAwQgeMV5xteBvrzKFwiToucMTrPPVL/KO2mEXvWP2Or7MY03DFu7w==


### PR DESCRIPTION
Adds a `go` target which produces bindings under `dist/go`. At the moment
we are still not publishing those to github.

jsii upgrade required.

Fixes https://github.com/aws/jsii/issues/2459