### PR TITLE
chore: publish to aws/constructs-go

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
         run: npx -p jsii-release jsii-release-nuget
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-  release_go:
+  release_golang:
     name: Release to Go
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,3 +115,20 @@ jobs:
         run: npx -p jsii-release jsii-release-nuget
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+  release_go:
+    name: Release to Go
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: jsii/superchain
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+      - name: Release
+        run: npx -p jsii-release jsii-release-golang
+        env:
+          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}
+          GIT_USER_NAME: AWS CDK Team
+          GIT_USER_EMAIL: aws-cdk-dev@amazon.com

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -66,6 +66,11 @@
       "type": "build"
     },
     {
+      "name": "jsii-release",
+      "version": "^0.2.12",
+      "type": "build"
+    },
+    {
       "name": "json-schema",
       "type": "build"
     },

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -62,6 +62,7 @@
     },
     {
       "name": "jsii-release",
+      "version": "^0.2.11",
       "type": "build"
     },
     {
@@ -70,7 +71,7 @@
     },
     {
       "name": "projen",
-      "version": "^0.15.13",
+      "version": "^0.15.14",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -168,7 +168,7 @@
           "exec": "jsii-pacmak"
         },
         {
-          "exec": "./scripts/go-version-file.sh"
+          "exec": "echo $(node -p \"require('./version.json').version\") > dist/constructs/projen/version"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -168,7 +168,7 @@
           "exec": "jsii-pacmak"
         },
         {
-          "exec": "echo $(node -p \"require('./version.json').version\") > dist/constructs/projen/version"
+          "exec": "echo $(node -p \"require('./version.json').version\") > dist/go/constructs/version"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -166,6 +166,9 @@
       "steps": [
         {
           "exec": "jsii-pacmak"
+        },
+        {
+          "exec": "./scripts/go-version-file.sh"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -54,5 +54,6 @@ const project = new JsiiProject({
 
 // temporary until https://github.com/aws/jsii/pull/2492 is resolveds
 project.packageTask.exec('echo $(node -p "require(\'./version.json\').version") > dist/go/constructs/version');
+project.addDevDeps('jsii-release@^0.2.12');
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -50,4 +50,36 @@ const project = new JsiiProject({
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
 });
 
+project.releaseWorkflow.addJobs({
+  release_go: {
+    'name': 'Release to Go',
+    'needs': 'build',
+    'runs-on': 'ubuntu-latest',
+    'container': {
+      image: 'jsii/superchain',
+    },
+    'steps': [
+      {
+        name: 'Download build artifacts',
+        uses: 'actions/download-artifact@v1',
+        with: {
+          name: 'dist',
+        },
+      },
+      {
+        name: 'Release',
+        run: 'npx -p jsii-release jsii-release-golang',
+        env: {
+          GITHUB_TOKEN: '${{ secrets.GO_GITHUB_TOKEN }}',
+          GIT_USER_NAME: 'AWS CDK Team',
+          GIT_USER_EMAIL: 'aws-cdk-dev@amazon.com',
+        },
+      },
+    ],
+  },
+});
+
+// temporary until https://github.com/aws/jsii/pull/2492 is resolved
+project.packageTask.exec('./scripts/go-version-file.sh');
+
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -39,6 +39,8 @@ const project = new JsiiProject({
 
   publishToGo: {
     moduleName: 'github.com/aws/constructs-go',
+    gitUserName: 'AWS CDK Team',
+    gitUserEmail: 'aws-cdk-dev@amazon.com',
   },
 
   stability: 'stable',
@@ -50,36 +52,7 @@ const project = new JsiiProject({
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
 });
 
-project.releaseWorkflow.addJobs({
-  release_go: {
-    'name': 'Release to Go',
-    'needs': 'build',
-    'runs-on': 'ubuntu-latest',
-    'container': {
-      image: 'jsii/superchain',
-    },
-    'steps': [
-      {
-        name: 'Download build artifacts',
-        uses: 'actions/download-artifact@v1',
-        with: {
-          name: 'dist',
-        },
-      },
-      {
-        name: 'Release',
-        run: 'npx -p jsii-release jsii-release-golang',
-        env: {
-          GITHUB_TOKEN: '${{ secrets.GO_GITHUB_TOKEN }}',
-          GIT_USER_NAME: 'AWS CDK Team',
-          GIT_USER_EMAIL: 'aws-cdk-dev@amazon.com',
-        },
-      },
-    ],
-  },
-});
-
-// temporary until https://github.com/aws/jsii/pull/2492 is resolved
-project.packageTask.exec('./scripts/go-version-file.sh');
+// temporary until https://github.com/aws/jsii/pull/2492 is resolveds
+project.packageTask.exec('echo $(node -p "require(\'./version.json\').version") > dist/constructs/projen/version');
 
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -53,6 +53,6 @@ const project = new JsiiProject({
 });
 
 // temporary until https://github.com/aws/jsii/pull/2492 is resolveds
-project.packageTask.exec('echo $(node -p "require(\'./version.json\').version") > dist/constructs/projen/version');
+project.packageTask.exec('echo $(node -p "require(\'./version.json\').version") > dist/go/constructs/version');
 
 project.synth();

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jsii-diff": "^1.18.0",
     "jsii-docgen": "^1.3.2",
     "jsii-pacmak": "^1.18.0",
-    "jsii-release": "^0.2.11",
+    "jsii-release": "^0.2.12",
     "json-schema": "^0.2.5",
     "projen": "^0.15.14",
     "standard-version": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jsii-diff": "^1.18.0",
     "jsii-docgen": "^1.3.2",
     "jsii-pacmak": "^1.18.0",
-    "jsii-release": "^0.2.3",
+    "jsii-release": "^0.2.11",
     "json-schema": "^0.2.5",
     "projen": "^0.15.13",
     "standard-version": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "jsii-pacmak": "^1.18.0",
     "jsii-release": "^0.2.11",
     "json-schema": "^0.2.5",
-    "projen": "^0.15.13",
+    "projen": "^0.15.14",
     "standard-version": "^9.0.0",
     "ts-jest": "^26.1.0",
     "typescript": "^3.9.5"

--- a/scripts/go-version-file.sh
+++ b/scripts/go-version-file.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-scriptdir=$(cd $(dirname $0) && pwd)
-version="$(node -p "require('${scriptdir}/../version.json').version")"
-echo ${version} > dist/go/constructs/version

--- a/scripts/go-version-file.sh
+++ b/scripts/go-version-file.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+scriptdir=$(cd $(dirname $0) && pwd)
+version="$(node -p "require('${scriptdir}/../version.json').version")"
+echo ${version} > dist/go/constructs/version

--- a/yarn.lock
+++ b/yarn.lock
@@ -3670,10 +3670,10 @@ jsii-reflect@^1.16.0, jsii-reflect@^1.18.0:
     oo-ascii-tree "^1.18.0"
     yargs "^16.2.0"
 
-jsii-release@^0.2.3:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/jsii-release/-/jsii-release-0.2.10.tgz#22689aed90d240023692199c9a154dbc0e6e7167"
-  integrity sha512-Pc2tQj+BiaXZYmcjq6us1/eL2YPItvjWjG9MJCnn6o1tCWnxkaKsRG0XiqgX/sjYjUIdP5YGmjZlxMZqZ7co4Q==
+jsii-release@^0.2.11:
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/jsii-release/-/jsii-release-0.2.11.tgz#51694fa5d4f95f75cded76ea8f834dacd9cedfd1"
+  integrity sha512-0E7/KmZy8xCpZ11A18nTv6eLHx7kREQqEb6OuBo+8U0e9XTfDlMxxw69xWvdJEg8Pjc1YGV08LIFC4fW4ZkyHg==
 
 jsii-rosetta@^1.18.0:
   version "1.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4677,10 +4677,10 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.15.13:
-  version "0.15.13"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.15.13.tgz#5eed6d4e86445ac25d7e0190fe769cb0a9934582"
-  integrity sha512-DImqeudBk+7fLZzvIiHwex556oSOclMZdfyy+Oeu7Jz0UPDU+y3+X10KZ3AVufL8IZi+kNozCY53ZToNBSHSUg==
+projen@^0.15.14:
+  version "0.15.14"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.15.14.tgz#43db1fdd515fb0ebaa92779d77d4bb5db98a9526"
+  integrity sha512-fYxuV63nmvmRrWkNIUsOtjWzBnNYhmeNHNpAenweOnK50qC6cmJhNatsizZlwVuP1YwyfBjvgJKdoGmLv+SVOg==
   dependencies:
     "@iarna/toml" "^2.2.5"
     chalk "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3670,10 +3670,10 @@ jsii-reflect@^1.16.0, jsii-reflect@^1.18.0:
     oo-ascii-tree "^1.18.0"
     yargs "^16.2.0"
 
-jsii-release@^0.2.11:
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/jsii-release/-/jsii-release-0.2.11.tgz#51694fa5d4f95f75cded76ea8f834dacd9cedfd1"
-  integrity sha512-0E7/KmZy8xCpZ11A18nTv6eLHx7kREQqEb6OuBo+8U0e9XTfDlMxxw69xWvdJEg8Pjc1YGV08LIFC4fW4ZkyHg==
+jsii-release@^0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/jsii-release/-/jsii-release-0.2.12.tgz#f8101b94302131766ea35c67a864d7412d2424bf"
+  integrity sha512-y+DLjmvDxiFsuu2xC0n9x3A7ZUh5cRVgLvLldhy9bhnLm4cRIn4O8fNooqWR17qbxMIdZxLp7WmOO1UpFq1slA==
 
 jsii-rosetta@^1.18.0:
   version "1.18.0"


### PR DESCRIPTION
Use the latest version of jsii-release to publish go releases to https://github.com/aws/constructs-go (currently private).
Until aws/jsii#2492 is resolved, add a build step which creates a `version` file in the go publish directory.

