### PR TITLE
chore: specify new sonatype endpoint

### DIFF
--- a/.github/workflows/release-10.x.yml
+++ b/.github/workflows/release-10.x.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Release
         run: npx -p jsii-release@latest jsii-release-maven
         env:
+          MAVEN_ENDPOINT: https://s01.oss.sonatype.org
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Release
         run: npx -p jsii-release@latest jsii-release-maven
         env:
+          MAVEN_ENDPOINT: https://s01.oss.sonatype.org
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -218,6 +218,9 @@
     "publish:maven": {
       "name": "publish:maven",
       "description": "Publish this package to Maven Central",
+      "env": {
+        "MAVEN_ENDPOINT": "https://s01.oss.sonatype.org"
+      },
       "requiredEnv": [
         "MAVEN_GPG_PRIVATE_KEY",
         "MAVEN_GPG_PRIVATE_KEY_PASSPHRASE",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -32,6 +32,7 @@ const project = new JsiiProject({
     javaPackage: 'software.constructs',
     mavenGroupId: 'software.constructs',
     mavenArtifactId: 'constructs',
+    mavenEndpoint: 'https://s01.oss.sonatype.org',
   },
 
   publishToPypi: {


### PR DESCRIPTION
The cdklabs-automation account is associated with the new sonatype endpoint https://s01.oss.sonatype.org, so we need to publish to it.

