### PR TITLE
chore(3.x): use a different staging profile id for software.constructs

### DIFF
--- a/.github/workflows/release-10.x.yml
+++ b/.github/workflows/release-10.x.yml
@@ -109,7 +109,7 @@ jobs:
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.CONSTRUCTS_MAVEN_STAGING_PROFILE_ID }}
     container:
       image: jsii/superchain:1-buster-slim-node14
   release_pypi:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.CONSTRUCTS_MAVEN_STAGING_PROFILE_ID }}
     container:
       image: jsii/superchain:1-buster-slim-node14
   release_pypi:

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -32,6 +32,7 @@ const project = new JsiiProject({
     javaPackage: 'software.constructs',
     mavenGroupId: 'software.constructs',
     mavenArtifactId: 'constructs',
+    mavenStagingProfileId: 'CONSTRUCTS_MAVEN_STAGING_PROFILE_ID',
     mavenEndpoint: 'https://s01.oss.sonatype.org',
   },
 


### PR DESCRIPTION
`software.constructs` has a different staging profile ID, so we added a new secret to cdklabs that includes it.