### PR TITLE
chore: documentation refers to invalid field `uniqueId`

### DIFF
--- a/src/construct.ts
+++ b/src/construct.ts
@@ -42,7 +42,7 @@ export class Node {
   /**
    * The id of this construct within the current scope.
    *
-   * This is a a scope-unique id. To obtain an app-unique id for this construct, use `uniqueId`.
+   * This is a a scope-unique id. To obtain an app-unique id for this construct, use `addr`.
    */
   public readonly id: string;
 


### PR DESCRIPTION
Fixes #787