### PR TITLE
fix: `isConstruct` is wrong when symlinking libraries

### DIFF
--- a/API.md
+++ b/API.md
@@ -80,9 +80,23 @@ toString(): string
 __Returns__:
 * <code>string</code>
 
-#### *static* isConstruct(x)⚠️ <a id="constructs-construct-isconstruct"></a>
+#### *static* isConstruct(x) <a id="constructs-construct-isconstruct"></a>
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ```ts
 static isConstruct(x: any): boolean


### PR DESCRIPTION
`Construct.isConstruct` was still using (and recommending) `instanceof`,
even though `instanceof` can never be made to work reliably.

When we thought `instanceof` was safe to use again, it's because we
thought that `npm install` combined with `peerDependencies` would
make sure only one copy of `constructs` would ever be installed.

That's correct, but monorepos and users using `npm link` can
still mess up that guarantee, so we cannot rely on it after all.
