### PR TITLE
chore: replaced leftover use of deprecated `Node.of` method

### DIFF
--- a/src/construct.ts
+++ b/src/construct.ts
@@ -98,7 +98,7 @@ export class Node {
    */
   public get addr(): string {
     if (!this._addr) {
-      this._addr = addressOf(this.scopes.map(c => Node.of(c).id));
+      this._addr = addressOf(this.scopes.map(c => c.node.id));
     }
 
     return this._addr;


### PR DESCRIPTION
Everywhere in the code `construct.node` is used in favor of the deprecated method `Node.of(construct)`. I changed this leftover call of `Node.of(construct` within the `Node.addr` method.

Fixes #1092 