### PR TITLE
chore: removed not existing parameter from Construct.constructor docum…

### DIFF
--- a/src/construct.ts
+++ b/src/construct.ts
@@ -458,7 +458,6 @@ export class Construct implements IConstruct {
    * @param id The scoped construct ID. Must be unique amongst siblings. If
    * the ID includes a path separator (`/`), then it will be replaced by double
    * dash `--`.
-   * @param options Options
    */
   constructor(scope: Construct, id: string) {
     this.node = new Node(this, scope, id);


### PR DESCRIPTION
…entation

Fixed the linter advice:

```
JSDoc '@param' tag has name 'options', but there is no parameter with that name.ts(8024)
```

Fixes #1094