### PR TITLE
feat(construct): improve typing for tryGetContext

### DIFF
--- a/src/construct.ts
+++ b/src/construct.ts
@@ -217,13 +217,13 @@ export class Node {
    * Context is usually initialized at the root, but can be overridden at any point in the tree.
    *
    * @param key The context key
-   * @returns The context value or `undefined` if there is no context value for thie key.
+   * @returns The context value or `undefined` if there is no context value for this key.
    */
-  public tryGetContext(key: string): any {
+  public tryGetContext<ContextValue = any>(key: string): ContextValue | undefined {
     const value = this._context[key];
     if (value !== undefined) { return value; }
 
-    return this.scope && this.scope.node.tryGetContext(key);
+    return this.scope && this.scope.node.tryGetContext<ContextValue>(key);
   }
 
   /**


### PR DESCRIPTION
Hello!

Currently typing for `tryGetContext` is only `any. This does not allow for fine-grained type handling.

For example, if I know that the context value is a string, I have to write:
```ts
const myValue = app.node.tryGetContext('myKey') as string | undefined;
```

This PR proposes to add an optional generic type argument. With it, we could write:
```ts
const myValue = app.node.tryGetContext<string>('myKey');
```
and the result would have type `string | undefined`

Thanks a lot for your time!