### PR TITLE
fix: `engine` specifies a higher version than it needs

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -54,7 +54,8 @@ const project = new cdk.JsiiProject({
   },
 
   stability: 'stable',
-  minNodeVersion: '14.18.0',
+  minNodeVersion: '14.17.0',
+  workflowNodeVersion: '14.18.0',
 
   compat: true,
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "jsii"
   ],
   "engines": {
-    "node": ">= 14.18.0"
+    "node": ">= 14.17.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
The engine bump was introduced [here](https://github.com/aws/constructs/pull/1611), when in fact only a build time node version needed a bump.