### PR TITLE
feat: add getContext function

### DIFF
--- a/API.md
+++ b/API.md
@@ -344,6 +344,21 @@ findChild(id: string): IConstruct
 __Returns__:
 * <code>[IConstruct](#constructs-iconstruct)</code>
 
+#### getContext(key) <a id="constructs-node-getcontext"></a>
+
+Retrieves a value from tree context if present. Otherwise, would throw an error.
+
+Context is usually initialized at the root, but can be overridden at any point in the tree.
+
+```ts
+getContext(key: string): any
+```
+
+* **key** (<code>string</code>)  The context key.
+
+__Returns__:
+* <code>any</code>
+
 #### lock() <a id="constructs-node-lock"></a>
 
 Locks this construct from allowing more children to be added.

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -212,12 +212,32 @@ export class Node {
   }
 
   /**
+   * Retrieves a value from tree context if present. Otherwise, would throw an error.
+   *
+   * Context is usually initialized at the root, but can be overridden at any point in the tree.
+   *
+   * @param key The context key
+   * @returns The context value or throws error if there is no context value for this key
+   */
+  public getContext(key: string): any {
+    const value = this._context[key];
+
+    if (value !== undefined) { return value; }
+
+    if (value === undefined && !this.scope?.node) {
+      throw new Error(`No context value present for ${key} key`);
+    }
+
+    return this.scope && this.scope.node.getContext(key);
+  }
+
+  /**
    * Retrieves a value from tree context.
    *
    * Context is usually initialized at the root, but can be overridden at any point in the tree.
    *
    * @param key The context key
-   * @returns The context value or `undefined` if there is no context value for thie key.
+   * @returns The context value or `undefined` if there is no context value for this key.
    */
   public tryGetContext(key: string): any {
     const value = this._context[key];

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -118,7 +118,39 @@ test('construct.getChild(name) can be used to retrieve a child from a parent', (
   expect(() => root.node.findChild('NotFound')).toThrow(/No child with id: 'NotFound'/);
 });
 
-test('construct.getContext(key) can be used to read a value from context defined at the root level', () => {
+test('construct.getContext(key) can be used to read a value from context', () => {
+  // GIVEN
+  const context = {
+    ctx1: 12,
+    ctx2: 'hello',
+  };
+
+  // WHEN
+  const t = createTree(context);
+
+  // THEN
+  expect(t.child1_2.node.getContext('ctx1')).toBe(12);
+  expect(t.child1_1_1.node.getContext('ctx2')).toBe('hello');
+});
+
+test('construct.getContext(key) throws if context is not defined', () => {
+  // GIVEN
+  const context = {
+    ctx1: 12,
+  };
+
+  // WHEN
+  const t = createTree(context);
+  const key = 'ctx2';
+
+  // THEN
+  expect(t.child1_2.node.getContext('ctx1')).toBe(12);
+  expect(() => {
+    t.child1_1_1.node.getContext(key);
+  }).toThrowError(`No context value present for ${key} key`);
+});
+
+test('construct.tryGetContext(key) can be used to read a value from context defined at the root level', () => {
   const context = {
     ctx1: 12,
     ctx2: 'hello',
@@ -130,7 +162,7 @@ test('construct.getContext(key) can be used to read a value from context defined
 });
 
 // tslint:disable-next-line:max-line-length
-test('construct.setContext(k,v) sets context at some level and construct.getContext(key) will return the lowermost value defined in the stack', () => {
+test('construct.setContext(k,v) sets context at some level and construct.tryGetContext(key) will return the lowermost value defined in the stack', () => {
   const root = new Root();
   const highChild = new Construct(root, 'highChild');
   highChild.node.setContext('c1', 'root');
@@ -161,7 +193,6 @@ test('construct.setContext(k,v) sets context at some level and construct.getCont
   expect(child3.node.tryGetContext('c2')).toBe('child1');
   expect(child3.node.tryGetContext('c3')).toBe('child1');
   expect(child3.node.tryGetContext('c4')).toBe('child3');
-
 });
 
 test('construct.setContext(key, value) can only be called before adding any children', () => {


### PR DESCRIPTION
Currently our `tryGetContext` function returns undefined if the context is not present in the scope tree. This `getContext` function would enable the same functionality but instead of returning undefined, it would throw an error if the context is not present.

Fixes https://github.com/aws/aws-cdk/issues/1771