### PR TITLE
chore: remove hard deprecations from .validate

### DIFF
--- a/src/construct.ts
+++ b/src/construct.ts
@@ -400,19 +400,7 @@ export class Node {
    * construct.
    */
   public validate(): string[] {
-    const deprecated = ['validate', 'onValidate', 'synthesize', 'onSynthesize', 'prepare', 'onPrepare'];
-    for (const method of deprecated) {
-      if (typeof((this.host as any)[method]) === 'function') {
-        throw new Error(`the construct "${this.path}" has a "${method}()" method which is no longer supported. Use "construct.node.addValidation()" to add validations to a construct`);
-      }
-    }
-
-    const errors = new Array<string>();
-    for (const v of this._validations) {
-      errors.push(...v.validate());
-    }
-
-    return errors;
+    return this._validations.flatMap(v => v.validate());
   }
 
   /**

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -641,21 +641,6 @@ test('Construct.isConstruct returns true for constructs', () => {
   expect(Construct.isConstruct(someRandomObject)).toBeFalsy();
 });
 
-describe('hard deprecations', () => {
-  const methods = ['validate', 'onValidate', 'synthesize', 'onSynthesize', 'prepare', 'onPrepare'];
-
-  for (const method of methods) {
-    test(method, () => {
-      const c = new Construct(new Root(), 'MyConstruct');
-      Object.defineProperty(c, method, {
-        value: () => [],
-      });
-
-      expect(() => c.node.validate()).toThrow(/no longer supported/);
-    });
-  }
-});
-
 function createTree(context?: any) {
   const root = new Root();
   const highChild = new Construct(root, 'HighChild');


### PR DESCRIPTION
This PR removes hard coded deprecation from `.validate` function. While it had some sense when it was added 3 years ago on 3.x->10.x migration, today it's just a piece of legacy / tech debt complicating `constructs` adoption in [some cases](https://github.com/projen/projen/issues/3056).

AWS CDK 1.x is now EOL, this code violates [JSII way to do deprecations](https://aws.github.io/jsii/user-guides/lib-author/toolchain/jsii/#-strip-deprecated) and definitely violates several OOP principles attempting to control shape of subclassing objects.