### PR TITLE
chore: bump node version to 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -122,7 +122,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -175,7 +175,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -203,7 +203,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/release-3.x.yml
+++ b/.github/workflows/release-3.x.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release:3.x
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -131,7 +131,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -202,7 +202,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -236,7 +236,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release:10.x
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -131,7 +131,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -202,7 +202,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -236,7 +236,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/upgrade-10.x.yml
+++ b/.github/workflows/upgrade-10.x.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-3.x.yml
+++ b/.github/workflows/upgrade-3.x.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-dev-deps-10.x.yml
+++ b/.github/workflows/upgrade-dev-deps-10.x.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-dev-deps-3.x.yml
+++ b/.github/workflows/upgrade-dev-deps-3.x.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^16",
+      "version": "^18",
       "type": "build"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -56,8 +56,8 @@ const project = new CdklabsJsiiProject({
   },
 
   stability: 'stable',
-  minNodeVersion: '16.14.0',
-  workflowNodeVersion: '16.x',
+  minNodeVersion: '18.12.0',
+  workflowNodeVersion: '18.x',
 
   compat: true,
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27",
-    "@types/node": "^16",
+    "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",
     "cdklabs-projen-project-types": "^0.1.188",
@@ -70,7 +70,7 @@
     "jsii"
   ],
   "engines": {
-    "node": ">= 16.14.0"
+    "node": ">= 18.12.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,10 +796,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^16":
-  version "16.18.80"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.80.tgz#9644e2d8acaf8163d46d23e05ce3822e9379dfc3"
-  integrity sha512-vFxJ1Iyl7A0+xB0uW1r1v504yItKZLdqg/VZELUZ4H02U0bXAgBisSQ8Erf0DMruNFz9ggoiEv6T8Ll9bTg8Jw==
+"@types/node@^18":
+  version "18.19.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.15.tgz#313a9d75435669a57fc28dc8694e7f4c4319f419"
+  integrity sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"


### PR DESCRIPTION
Currently seeing workflows(`npx projen upgrade-dev-deps`) failing with,

```
error jsii@5.3.15: The engine "node" is incompatible with this module. Expected version ">= 18.12.0". Got "16.20.2"
```

Bumping the node version to 18 in this PR.

--------

Tested by running `npx projen upgrade-dev-deps` locally successfully.