### PR TITLE
chore: updated the documentation on addMetadata

### DIFF
--- a/API.md
+++ b/API.md
@@ -501,6 +501,8 @@ Adds a metadata entry to this construct.
 Entries are arbitrary values and will also include a stack trace to allow tracing back to
 the code location for when the entry was added. It can be used, for example, to include source
 mapping in CloudFormation templates to improve diagnostics.
+Note that construct metadata is not the same as CloudFormation resource metadata and is never written to the CloudFormation template.
+The metadata entries are written to the Cloud Assembly Manifest if the `treeMetadata` property is specified in the props of the App that contains this Construct.
 
 ###### `type`<sup>Required</sup> <a name="type" id="constructs.Node.addMetadata.parameter.type"></a>
 

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -281,7 +281,7 @@ export class Node {
   /**
    * Adds a metadata entry to this construct.
    * Note that construct metadata is not the same as CloudFormation resource metadata and is never written to the CloudFormation template.
-   * The metadata entries are written to the Cloud Assembly Manifest if the treeMetadata property is specified in the props of the App that contains this Construct.
+   * The metadata entries are written to the Cloud Assembly Manifest if the treeMetadata property is specified in the props of the App that contains this Construct..
    *
    * @param type a string denoting the type of metadata
    * @param data the value of the metadata (can be a Token). If null/undefined, metadata will not be added.

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -284,7 +284,7 @@ export class Node {
    * the code location for when the entry was added. It can be used, for example, to include source
    * mapping in CloudFormation templates to improve diagnostics.
    * Note that construct metadata is not the same as CloudFormation resource metadata and is never written to the CloudFormation template.
-   * The metadata entries are written to the Cloud Assembly Manifest if the 'treeMetadata' property is specified in the props of the App that contains this Construct.
+   * The metadata entries are written to the Cloud Assembly Manifest if the `treeMetadata` property is specified in the props of the App that contains this Construct.
    *
    * @param type a string denoting the type of metadata
    * @param data the value of the metadata (can be a Token). If null/undefined, metadata will not be added.

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -284,7 +284,7 @@ export class Node {
    * the code location for when the entry was added. It can be used, for example, to include source
    * mapping in CloudFormation templates to improve diagnostics.
    * Note that construct metadata is not the same as CloudFormation resource metadata and is never written to the CloudFormation template.
-   * The metadata entries are written to the Cloud Assembly Manifest if the `treeMetadata` property is specified in the props of the App that contains this Construct.
+   * The metadata entries are written to the Cloud Assembly Manifest if the 'treeMetadata' property is specified in the props of the App that contains this Construct.
    *
    * @param type a string denoting the type of metadata
    * @param data the value of the metadata (can be a Token). If null/undefined, metadata will not be added.

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -280,8 +280,11 @@ export class Node {
 
   /**
    * Adds a metadata entry to this construct.
+   * Entries are arbitrary values and will also include a stack trace to allow tracing back to
+   * the code location for when the entry was added. It can be used, for example, to include source
+   * mapping in CloudFormation templates to improve diagnostics.
    * Note that construct metadata is not the same as CloudFormation resource metadata and is never written to the CloudFormation template.
-   * The metadata entries are written to the Cloud Assembly Manifest if the treeMetadata property is specified in the props of the App that contains this Construct..
+   * The metadata entries are written to the Cloud Assembly Manifest if the `treeMetadata` property is specified in the props of the App that contains this Construct.
    *
    * @param type a string denoting the type of metadata
    * @param data the value of the metadata (can be a Token). If null/undefined, metadata will not be added.

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -279,8 +279,9 @@ export class Node {
   }
 
   /**
-   * Adds a metadata entry to the CDK construct tree. View modification in Cloud Assembly manifest.json.
-   * Not written to Cloudformation template.
+   * Adds a metadata entry to this construct.
+   * Note that construct metadata is not the same as CloudFormation resource metadata and is never written to the CloudFormation template.
+   * The metadata entries are written to the Cloud Assembly Manifest if the treeMetadata property is specified in the props of the App that contains this Construct.
    *
    * @param type a string denoting the type of metadata
    * @param data the value of the metadata (can be a Token). If null/undefined, metadata will not be added.

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -279,10 +279,8 @@ export class Node {
   }
 
   /**
-   * Adds a metadata entry to this construct.
-   * Entries are arbitrary values and will also include a stack trace to allow tracing back to
-   * the code location for when the entry was added. It can be used, for example, to include source
-   * mapping in CloudFormation templates to improve diagnostics.
+   * Adds a metadata entry to the CDK construct tree. View modification in Cloud Assembly manifest.json.
+   * Not written to Cloudformation template.
    *
    * @param type a string denoting the type of metadata
    * @param data the value of the metadata (can be a Token). If null/undefined, metadata will not be added.


### PR DESCRIPTION
Clarify the understanding that the addMetadata is writing to the construct tree, visible in the cloud assembly of the manifest.json. Not visible in the Cloudformation template.