### PR TITLE
fix: rootNode.getAllContext() returns empty object 

### DIFF
--- a/src/construct.ts
+++ b/src/construct.ts
@@ -245,14 +245,8 @@ export class Node {
    * @returns The context object or an empty object if there is discovered context
    */
   public getAllContext(defaults?: object): any {
-    if (typeof defaults === 'undefined') {
-      defaults = {};
-    }
-
-    if (this.scope === undefined) { return defaults; }
-
-    const value = { ...this._context, ...defaults };
-    return this.scope && this.scope.node.getAllContext(value);
+    return this.scopes.reverse()
+        .reduce((a, s) => ({ ...(s.node._context), ...a }), { ...defaults });
   }
 
   /**

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -246,7 +246,7 @@ export class Node {
    */
   public getAllContext(defaults?: object): any {
     return this.scopes.reverse()
-        .reduce((a, s) => ({ ...(s.node._context), ...a }), { ...defaults });
+      .reduce((a, s) => ({ ...(s.node._context), ...a }), { ...defaults });
   }
 
   /**

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -150,6 +150,23 @@ test('construct.getContext(key) throws if context is not defined', () => {
   }).toThrowError(`No context value present for ${key} key`);
 });
 
+test('construct.getAllContext can be used to read the full context of a root node', () => {
+  // GIVEN
+  const context = {
+    ctx1: 12,
+    ctx2: 'hello',
+  };
+
+  // WHEN
+  const t = new Root();
+  for (const [k, v] of Object.entries(context)) {
+      t.node.setContext(k, v);
+  }
+
+  // THEN
+  expect(t.node.getAllContext()).toStrictEqual(context);
+});
+
 test('construct.getAllContext can be used to read the full context of a node', () => {
   // GIVEN
   const context = {

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -160,7 +160,7 @@ test('construct.getAllContext can be used to read the full context of a root nod
   // WHEN
   const t = new Root();
   for (const [k, v] of Object.entries(context)) {
-      t.node.setContext(k, v);
+    t.node.setContext(k, v);
   }
 
   // THEN


### PR DESCRIPTION
Correct getAllContext() to return the root node's context in addition to specified defaults.

Fixes: #2239 