### PR TITLE
feat: stabilize experimental code

### DIFF
--- a/src/construct.ts
+++ b/src/construct.ts
@@ -366,7 +366,6 @@ export class Node {
    * Remove the child with the given name, if present.
    *
    * @returns Whether a child with the given name was deleted.
-   * @experimental
    */
   public tryRemoveChild(childName: string): boolean {
     if (!(childName in this._children)) { return false; }

--- a/src/dependency.ts
+++ b/src/dependency.ts
@@ -20,8 +20,6 @@ export interface IDependable {
  *
  * This class can be used when a set of constructs which are disjoint in the
  * construct tree needs to be combined to be used as a single dependable.
- *
- * @experimental
  */
 export class DependencyGroup implements IDependable {
   private readonly _deps = new Array<IDependable>();
@@ -70,8 +68,6 @@ const DEPENDABLE_SYMBOL = Symbol.for('@aws-cdk/core.DependableTrait');
  * Dependable.implement(construct, {
  *       dependencyRoots: [construct],
  * });
- *
- * @experimental
  */
 export abstract class Dependable {
   /**


### PR DESCRIPTION
Fixes #2267

These code features have been around for a long time. There are no known issues around them. They are used in `aws-cdk-lib` and the team has effectively treated the code as stable anyway. It's also not great practice to main unstable code like this. Let's just stabilize the previously experimental parts.