### PR TITLE
fix: unnecessary strict node requirement in engines in package.json

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -51,8 +51,7 @@ const project = new CdklabsJsiiProject({
   },
 
   stability: 'stable',
-  minNodeVersion: '18.12.0',
-
+  setNodeEngineVersion: false,
   compat: true,
 
   autoApproveOptions: {

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Constructs are classes which define a "piece of system state". Constructs can be
 
 Constructs are often used to represent the _desired state_ of cloud applications. For example, in the AWS CDK, which is used to define the desired state for AWS infrastructure using CloudFormation, the lowest-level construct represents a _resource definition_ in a CloudFormation template. These resources are composed to represent higher-level logical units of a cloud application, etc.
 
+## Support policy
+
+All [maintained Node.js versions](https://nodejs.org/en/about/previous-releases#release-schedule) are supported by this package.
+
 ## Contributing
 
 This project has adopted the [Amazon Open Source Code of

--- a/package.json
+++ b/package.json
@@ -69,9 +69,6 @@
     "constructs",
     "jsii"
   ],
-  "engines": {
-    "node": ">= 18.12.0"
-  },
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aws/constructs",


### PR DESCRIPTION
Fixes #1329 

We already use jsii to manage Node.js versions. No need to overzealously enforce via engines.