### PR TITLE
chore: deprecate constructs 3.x

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -56,7 +56,7 @@ const project = new CdklabsJsiiProject({
     gitUserEmail: 'aws-cdk-dev@amazon.com',
   },
 
-  stability: 'stable',
+  stability: 'deprecated',
 
   minNodeVersion: '16.14.0',
   workflowNodeVersion: '18.x',

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Constructs
 
+---
+
+![Deprecated](https://img.shields.io/badge/deprecated-critical.svg?style=for-the-badge)
+
+> This API may emit warnings. Backward compatibility is not guaranteed. Use Constructs 10.x which is compatible with CDK 2.x.
+
+---
+
 > Software-defined persistent state
 
 ![Release](https://github.com/aws/constructs/workflows/Release/badge.svg)

--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
     }
   },
   "types": "lib/index.d.ts",
-  "stability": "stable",
+  "stability": "deprecated",
+  "deprecated": true,
   "jsii": {
     "outdir": "dist",
     "targets": {


### PR DESCRIPTION
Since we've stopped releasing constructs 3.x this is more for bookkeeping. marking 3.x as deprecated.