### PR TITLE
fix(python): only allow Typeguard 2.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ To release a new version, run `yarn bump` which will:"
 Then, execute:
 
 ```shell
-git push --follow-tags origin master
+git push --follow-tags origin main
 ```
 
 Once the commit is pushed to master, the [release


### PR DESCRIPTION
Forcing a release of https://github.com/aws/constructs/pull/2830 since this got inadvertently merged as a `chore` and therefore not causing a release.