### PR TITLE
chore: update maven central badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm version](https://badge.fury.io/js/constructs.svg)](https://badge.fury.io/js/constructs)
 [![PyPI version](https://badge.fury.io/py/constructs.svg)](https://badge.fury.io/py/constructs)
 [![NuGet version](https://badge.fury.io/nu/Constructs.svg)](https://badge.fury.io/nu/Constructs)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/software.constructs/constructs/badge.svg?style=plastic)](https://maven-badges.herokuapp.com/maven-central/software.constructs/constructs)
+[![Maven Central](https://maven-badges.sml.io/maven-central/software.constructs/constructs/badge.svg?style=plastic)](https://central.sonatype.com/artifact/software.constructs/constructs)
 
 ## What are constructs?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm version](https://badge.fury.io/js/constructs.svg)](https://badge.fury.io/js/constructs)
 [![PyPI version](https://badge.fury.io/py/constructs.svg)](https://badge.fury.io/py/constructs)
 [![NuGet version](https://badge.fury.io/nu/Constructs.svg)](https://badge.fury.io/nu/Constructs)
-[![Maven Central](https://maven-badges.sml.io/maven-central/software.constructs/constructs/badge.svg?style=plastic)](https://central.sonatype.com/artifact/software.constructs/constructs)
+[![Maven Central](https://maven-badges.sml.io/maven-central/software.constructs/constructs/badge.svg?style=plastic)](https://maven-badges.sml.io/maven-central/software.constructs/constructs)
 
 ## What are constructs?
 


### PR DESCRIPTION
Broken shield and link to maven central in the README (which I saw on construct hub). 

According to https://github.com/softwaremill/maven-badges 
https://maven-badges.herokuapp.com migrated to https://maven-badges.sml.io
