### PR TITLE
chore: enforce consistent type imports and exports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -209,7 +209,9 @@
           "method"
         ]
       }
-    ]
+    ],
+    "@typescript-eslint/consistent-type-exports": "error",
+    "@typescript-eslint/consistent-type-imports": "error"
   },
   "overrides": [
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -78,4 +78,10 @@ project.npmignore?.exclude('/scripts/', '.projenrc.ts');
 // cdklabs-projen-project-types is overzealous about adding this dependency
 project.deps.removeDependency('constructs');
 
+// modern type imports/exports
+project.eslint?.addRules({
+  '@typescript-eslint/consistent-type-exports': 'error',
+  '@typescript-eslint/consistent-type-imports': 'error',
+});
+
 project.synth();

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -1,5 +1,6 @@
-import { Dependable, IDependable } from './dependency';
-import { MetadataEntry } from './metadata';
+import type { IDependable } from './dependency';
+import { Dependable } from './dependency';
+import type { MetadataEntry } from './metadata';
 import { captureStackTrace } from './private/stack-trace';
 import { addressOf } from './private/uniqueid';
 

--- a/src/dependency.ts
+++ b/src/dependency.ts
@@ -1,4 +1,4 @@
-import { IConstruct } from './construct';
+import type { IConstruct } from './construct';
 
 /**
  * Trait marker for classes that can be depended upon

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './construct';
-export * from './metadata';
+export type * from './metadata';
 export * from './dependency';

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -1,5 +1,6 @@
 import { App as Root } from './util';
-import { Construct, ConstructOrder, DependencyGroup, Dependable, IConstruct } from '../src';
+import type { IConstruct } from '../src';
+import { Construct, ConstructOrder, DependencyGroup, Dependable } from '../src';
 
 // tslint:disable:variable-name
 // tslint:disable:max-line-length


### PR DESCRIPTION
This change adds ESLint rules to enforce consistent use of type-only imports and exports across the codebase.

Using `import type` and `export type` syntax improves code clarity by making it explicit when an import is only used for type information. This distinction helps TypeScript's `isolatedModules` mode and enables better tree-shaking in bundlers, as type-only imports are completely erased during compilation.

The rules are configured via projen and applied to all source and test files.
