### PR TITLE
feat(mixin): add IMixin interface and Construct.with() method

### DIFF
--- a/API.md
+++ b/API.md
@@ -51,6 +51,7 @@ dash `--`.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#constructs.Construct.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#constructs.Construct.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -61,6 +62,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="constructs.Construct.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="constructs.Construct.with.parameter.mixins"></a>
+
+- *Type:* ...<a href="#constructs.IMixin">IMixin</a>[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -161,6 +183,7 @@ dash `--`.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#constructs.RootConstruct.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#constructs.RootConstruct.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -171,6 +194,27 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `with` <a name="with" id="constructs.RootConstruct.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="constructs.RootConstruct.with.parameter.mixins"></a>
+
+- *Type:* ...<a href="#constructs.IMixin">IMixin</a>[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -1066,6 +1110,32 @@ Separator used to delimit construct path components.
 
 Represents a construct.
 
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#constructs.IConstruct.with">with</a></code> | Applies one or more mixins to this construct. |
+
+---
+
+##### `with` <a name="with" id="constructs.IConstruct.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="constructs.IConstruct.with.parameter.mixins"></a>
+
+- *Type:* ...<a href="#constructs.IMixin">IMixin</a>[]
+
+The mixins to apply.
+
+---
 
 #### Properties <a name="Properties" id="Properties"></a>
 
@@ -1101,6 +1171,50 @@ constructs. An ordering dependency implies that the resources represented by
 those constructs are deployed before the resources depending ON them are
 deployed.
 
+
+
+### IMixin <a name="IMixin" id="constructs.IMixin"></a>
+
+- *Implemented By:* <a href="#constructs.IMixin">IMixin</a>
+
+A mixin is a reusable piece of functionality that can be applied to constructs to add behavior, properties, or modify existing functionality without inheritance.
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#constructs.IMixin.applyTo">applyTo</a></code> | Applies the mixin functionality to the target construct. |
+| <code><a href="#constructs.IMixin.supports">supports</a></code> | Determines whether this mixin can be applied to the given construct. |
+
+---
+
+##### `applyTo` <a name="applyTo" id="constructs.IMixin.applyTo"></a>
+
+```typescript
+public applyTo(construct: IConstruct): void
+```
+
+Applies the mixin functionality to the target construct.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="constructs.IMixin.applyTo.parameter.construct"></a>
+
+- *Type:* <a href="#constructs.IConstruct">IConstruct</a>
+
+---
+
+##### `supports` <a name="supports" id="constructs.IMixin.supports"></a>
+
+```typescript
+public supports(construct: IConstruct): boolean
+```
+
+Determines whether this mixin can be applied to the given construct.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="constructs.IMixin.supports.parameter.construct"></a>
+
+- *Type:* <a href="#constructs.IConstruct">IConstruct</a>
+
+---
 
 
 ### IValidation <a name="IValidation" id="constructs.IValidation"></a>

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -1,6 +1,7 @@
 import type { IDependable } from './dependency';
 import { Dependable } from './dependency';
 import type { MetadataEntry } from './metadata';
+import type { IMixin } from './mixin';
 import { captureStackTrace } from './private/stack-trace';
 import { addressOf } from './private/uniqueid';
 
@@ -14,6 +15,17 @@ export interface IConstruct extends IDependable {
    * The tree node.
    */
   readonly node: Node;
+
+  /**
+   * Applies one or more mixins to this construct.
+   *
+   * Mixins are applied in order. The list of constructs is captured at the
+   * start of the call, so constructs added by a mixin will not be visited.
+   *
+   * @param mixins The mixins to apply
+   * @returns This construct for chaining
+   */
+  with(...mixins: IMixin[]): IConstruct;
 }
 
 /**
@@ -504,6 +516,29 @@ export class Construct implements IConstruct {
       dependencyRoots: [this],
     });
   }
+
+  /**
+   * Applies one or more mixins to this construct.
+   *
+   * Mixins are applied in order. The list of constructs is captured at the
+   * start of the call, so constructs added by a mixin will not be visited.
+   * Use multiple `with()` calls if subsequent mixins should apply to added
+   * constructs.
+   *
+   * @param mixins The mixins to apply
+   * @returns This construct for chaining
+   */
+  public with(...mixins: IMixin[]): IConstruct {
+    const allConstructs = this.node.findAll();
+    for (const mixin of mixins) {
+      for (const construct of allConstructs) {
+        if (mixin.supports(construct)) {
+          mixin.applyTo(construct);
+        }
+      }
+    }
+    return this;
+  };
 
   /**
    * Returns a string representation of this construct.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './construct';
 export type * from './metadata';
+export type * from './mixin';
 export * from './dependency';

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -1,0 +1,17 @@
+import type { IConstruct } from './construct';
+
+/**
+ * A mixin is a reusable piece of functionality that can be applied to constructs
+ * to add behavior, properties, or modify existing functionality without inheritance.
+ */
+export interface IMixin {
+  /**
+   * Determines whether this mixin can be applied to the given construct.
+   */
+  supports(construct: IConstruct): boolean;
+
+  /**
+   * Applies the mixin functionality to the target construct.
+   */
+  applyTo(construct: IConstruct): void;
+}

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -688,3 +688,160 @@ interface ValidationError {
   readonly source: IConstruct;
   readonly message: string;
 }
+
+describe('with() mixin support', () => {
+  test('returns the construct for chaining', () => {
+    const root = new Root();
+    const result = root.with();
+    expect(result).toBe(root);
+  });
+
+  test('applies a single mixin to the construct', () => {
+    const root = new Root();
+    const applied: IConstruct[] = [];
+    const mixin = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => applied.push(c),
+    };
+
+    root.with(mixin);
+
+    expect(applied).toContain(root);
+  });
+
+  test('applies multiple mixins to the construct', () => {
+    const root = new Root();
+    const applied1: IConstruct[] = [];
+    const applied2: IConstruct[] = [];
+    const mixin1 = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => applied1.push(c),
+    };
+    const mixin2 = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => applied2.push(c),
+    };
+
+    root.with(mixin1, mixin2);
+
+    expect(applied1).toContain(root);
+    expect(applied2).toContain(root);
+  });
+
+  test('applies mixin to all children in the tree', () => {
+    const root = new Root();
+    const child1 = new Construct(root, 'child1');
+    new Construct(root, 'child2');
+    new Construct(child1, 'grandchild');
+
+    const applied: string[] = [];
+    const mixin = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => applied.push(c.node.id || 'root'),
+    };
+
+    root.with(mixin);
+
+    expect(applied).toEqual(['root', 'child1', 'grandchild', 'child2']);
+  });
+
+  test('only applies mixin to constructs that pass supports() check', () => {
+    const root = new Root();
+    new Construct(root, 'child1');
+    new Construct(root, 'child2');
+
+    const applied: string[] = [];
+    const mixin = {
+      supports: (c: IConstruct) => c.node.id === 'child1',
+      applyTo: (c: IConstruct) => applied.push(c.node.id),
+    };
+
+    root.with(mixin);
+
+    expect(applied).toEqual(['child1']);
+  });
+
+  test('does not apply mixin when supports() returns false for all', () => {
+    const root = new Root();
+    new Construct(root, 'child1');
+
+    const applied: IConstruct[] = [];
+    const mixin = {
+      supports: () => false,
+      applyTo: (c: IConstruct) => applied.push(c),
+    };
+
+    root.with(mixin);
+
+    expect(applied).toHaveLength(0);
+  });
+
+  test('supports chaining multiple with() calls', () => {
+    const root = new Root();
+    const applied1: IConstruct[] = [];
+    const applied2: IConstruct[] = [];
+    const mixin1 = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => applied1.push(c),
+    };
+    const mixin2 = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => applied2.push(c),
+    };
+
+    root.with(mixin1).with(mixin2);
+
+    expect(applied1).toContain(root);
+    expect(applied2).toContain(root);
+  });
+
+  test('mixin can modify construct metadata', () => {
+    const root = new Root();
+    const mixin = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => c.node.addMetadata('mixin-applied', true),
+    };
+
+    root.with(mixin);
+
+    expect(root.node.metadata).toEqual([{ type: 'mixin-applied', data: true, trace: undefined }]);
+  });
+
+  test('applies mixins in order, completing each mixin before the next', () => {
+    const root = new Root();
+    new Construct(root, 'child');
+
+    const order: string[] = [];
+    const mixin1 = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => order.push(`m1:${c.node.id || 'root'}`),
+    };
+    const mixin2 = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => order.push(`m2:${c.node.id || 'root'}`),
+    };
+
+    root.with(mixin1, mixin2);
+
+    expect(order).toEqual(['m1:root', 'm1:child', 'm2:root', 'm2:child']);
+  });
+
+  test('does not apply mixins to constructs added by other mixins', () => {
+    const root = new Root();
+
+    const applied: string[] = [];
+    const addingMixin = {
+      supports: (c: IConstruct) => c.node.id === '',
+      applyTo: (c: IConstruct) => new Construct(c, 'added-by-mixin'),
+    };
+    const trackingMixin = {
+      supports: () => true,
+      applyTo: (c: IConstruct) => applied.push(c.node.id || 'root'),
+    };
+
+    root.with(addingMixin, trackingMixin);
+
+    expect(applied).toEqual(['root']);
+    expect(root.node.findChild('added-by-mixin')).toBeDefined();
+  });
+});


### PR DESCRIPTION
This PR implements the `constructs` package parts of [RFC-0814: CDK Mixins](https://github.com/aws/aws-cdk-rfcs/blob/58051ea8cc408b8ccd0d2c66dc1790ebb67da08f/text/0814-cdk-mixins.md).

CDK Mixins are composable, reusable abstractions that can be applied to any construct. This change adds the foundational support to the `constructs` library, enabling the fluent `.with()` API described in the RFC.

## Changes

The `IMixin` interface defines the contract for mixins with two methods:
- `supports(construct)` - determines if a mixin can be applied to a given construct
- `applyTo(construct)` - applies the mixin functionality to the target

The `with()` method is added to `Construct` and `IConstruct`, allowing mixins to be applied fluently. When called, it traverses the construct tree and applies each mixin to all supported constructs.

```typescript
const bucket = new s3.CfnBucket(scope, "MyBucket")
  .with(new EncryptionAtRest())
  .with(new AutoDeleteObjects());
```

## Why

Mixins are a new way to build abstractions, that does not rely on the construct level approach many implementors use. They allow users to employ a mix and match approach for features that doesn't lock consumers into specific implementations.

