### PR TITLE
fix: provide default implementation of `with()` on `Node` class

### DIFF
--- a/API.md
+++ b/API.md
@@ -625,6 +625,7 @@ new Node(host: Construct, scope: IConstruct, id: string)
 | <code><a href="#constructs.Node.tryGetContext">tryGetContext</a></code> | Retrieves a value from tree context. |
 | <code><a href="#constructs.Node.tryRemoveChild">tryRemoveChild</a></code> | Remove the child with the given name, if present. |
 | <code><a href="#constructs.Node.validate">validate</a></code> | Validates this construct. |
+| <code><a href="#constructs.Node.with">with</a></code> | Applies one or more mixins to this construct. |
 
 ---
 
@@ -867,6 +868,27 @@ Validates this construct.
 
 Invokes the `validate()` method on all validations added through
 `addValidation()`.
+
+##### `with` <a name="with" id="constructs.Node.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="constructs.Node.with.parameter.mixins"></a>
+
+- *Type:* ...<a href="#constructs.IMixin">IMixin</a>[]
+
+The mixins to apply.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -433,6 +433,29 @@ export class Node {
   }
 
   /**
+   * Applies one or more mixins to this construct.
+   *
+   * Mixins are applied in order. The list of constructs is captured at the
+   * start of the call, so constructs added by a mixin will not be visited.
+   * Use multiple `with()` calls if subsequent mixins should apply to added
+   * constructs.
+   *
+   * @param mixins The mixins to apply
+   * @returns This construct for chaining
+   */
+  public with(...mixins: IMixin[]): IConstruct {
+    const allConstructs = this.findAll();
+    for (const mixin of mixins) {
+      for (const construct of allConstructs) {
+        if (mixin.supports(construct)) {
+          mixin.applyTo(construct);
+        }
+      }
+    }
+    return this.host;
+  };
+
+  /**
    * Adds a child construct to this node.
    *
    * @param child The child construct
@@ -529,15 +552,7 @@ export class Construct implements IConstruct {
    * @returns This construct for chaining
    */
   public with(...mixins: IMixin[]): IConstruct {
-    const allConstructs = this.node.findAll();
-    for (const mixin of mixins) {
-      for (const construct of allConstructs) {
-        if (mixin.supports(construct)) {
-          mixin.applyTo(construct);
-        }
-      }
-    }
-    return this;
+    return this.node.with(...mixins);
   };
 
   /**


### PR DESCRIPTION
The `with()` method for applying mixins was previously only implemented directly on the `Construct` class. This made it difficult for custom `IConstruct` implementations to support mixins without duplicating the implementation logic.

This change moves the core implementation to the `Node` class, exposing it as `node.with()`. The `Construct.with()` method now simply delegates to this new implementation. Any custom `IConstruct` implementation can now easily support mixins by delegating to `this.node.with()`, following the same pattern.

This is particularly useful for libraries that extend the constructs model with their own base classes, as they no longer need to copy the mixin application logic.
