### PR TITLE
feat: add stackTraceOverride option to MetadataOptions

### DIFF
--- a/API.md
+++ b/API.md
@@ -357,6 +357,7 @@ const metadataOptions: MetadataOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#constructs.MetadataOptions.property.stackTrace">stackTrace</a></code> | <code>boolean</code> | Include stack trace with metadata entry. |
+| <code><a href="#constructs.MetadataOptions.property.stackTraceOverride">stackTraceOverride</a></code> | <code>string[]</code> | The actual stack trace to be added to the metadata. |
 | <code><a href="#constructs.MetadataOptions.property.traceFromFunction">traceFromFunction</a></code> | <code>any</code> | A JavaScript function to begin tracing from. |
 
 ---
@@ -371,6 +372,21 @@ public readonly stackTrace: boolean;
 - *Default:* false
 
 Include stack trace with metadata entry.
+
+---
+
+##### `stackTraceOverride`<sup>Optional</sup> <a name="stackTraceOverride" id="constructs.MetadataOptions.property.stackTraceOverride"></a>
+
+```typescript
+public readonly stackTraceOverride: string[];
+```
+
+- *Type:* string[]
+
+The actual stack trace to be added to the metadata.
+
+If this
+parameter is passed, the stackTrace parameter is ignored.
 
 ---
 

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -305,12 +305,19 @@ export class Node {
       return;
     }
 
-    const shouldTrace = options.stackTrace ?? false;
-    const trace = shouldTrace ? captureStackTrace(options.traceFromFunction ?? this.addMetadata) : undefined;
+    const node = this;
+    function getTrace() {
+      if (options.stackTraceOverride && options.stackTraceOverride.length > 0) {
+        return options.stackTraceOverride;
+      }
+      const shouldTrace = options.stackTrace ?? false;
+      return shouldTrace ? captureStackTrace(options.traceFromFunction ?? node.addMetadata) : undefined;
+    }
+
     if (!this._metadata) {
       this._metadata = [];
     }
-    this._metadata.push({ type, data, trace });
+    this._metadata.push({ type, data, trace: getTrace() });
   }
 
   /**
@@ -621,6 +628,12 @@ export interface MetadataOptions {
    * @default addMetadata()
    */
   readonly traceFromFunction?: any;
+
+  /**
+   * The actual stack trace to be added to the metadata. If this
+   * parameter is passed, the stackTrace parameter is ignored.
+   */
+  readonly stackTraceOverride?: string[];
 }
 
 // Mark all instances of 'Construct'

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -297,6 +297,22 @@ test('addMetadata() respects the "stackTrace" option', () => {
   expect(con.node.metadata[1]?.trace).toBeUndefined();
 });
 
+test('addMetadata() respects the "stackTraceOverride" option', () => {
+  const root = new Root();
+  const con = new Construct(root, 'Foo');
+  const customTrace = ['custom/path/file.ts:10', 'custom/path/other.ts:20'];
+
+  con.node.addMetadata('foo', 'bar1', { stackTraceOverride: customTrace });
+  con.node.addMetadata('foo', 'bar2', { stackTrace: true, stackTraceOverride: customTrace });
+  con.node.addMetadata('foo', 'bar3', { stackTraceOverride: [] });
+  con.node.addMetadata('foo', 'bar4', { stackTrace: true });
+
+  expect(con.node.metadata[0].trace).toEqual(customTrace);
+  expect(con.node.metadata[1].trace).toEqual(customTrace);
+  expect(con.node.metadata[2].trace).toBeUndefined();
+  expect(con.node.metadata[3].trace?.length).toBeGreaterThan(0);
+});
+
 test('addMetadata(type, undefined/null) is ignored', () => {
   const root = new Root();
   const con = new Construct(root, 'Foo');


### PR DESCRIPTION
Allow callers to provide a custom stack trace via the new `stackTraceOverride` property on `MetadataOptions`. When a non-empty array is supplied, it is used as-is and the `stackTrace` / `traceFromFunction` options are ignored.

