### PR TITLE
feat: removeDependency

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -58,6 +58,12 @@ const project = new CdklabsJsiiProject({
   },
   autoApproveUpgrades: true,
 
+  tsconfig: {
+    compilerOptions: {
+      types: ['jest', 'node'],
+    },
+  },
+
   jsiiVersion: '5.9.x',
   typescriptVersion: '5.9.x',
 });

--- a/API.md
+++ b/API.md
@@ -628,7 +628,7 @@ new Node(host: Construct, scope: IConstruct, id: string)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#constructs.Node.addDependency">addDependency</a></code> | Add an ordering dependency on another construct. |
+| <code><a href="#constructs.Node.addDependency">addDependency</a></code> | Add an ordering dependency on a Dependable (a construct or set of constructs). |
 | <code><a href="#constructs.Node.addMetadata">addMetadata</a></code> | Adds a metadata entry to this construct. |
 | <code><a href="#constructs.Node.addValidation">addValidation</a></code> | Adds a validation to this construct. |
 | <code><a href="#constructs.Node.findAll">findAll</a></code> | Return this construct and all of its children in the given order. |
@@ -636,6 +636,7 @@ new Node(host: Construct, scope: IConstruct, id: string)
 | <code><a href="#constructs.Node.getAllContext">getAllContext</a></code> | Retrieves the all context of a node from tree context. |
 | <code><a href="#constructs.Node.getContext">getContext</a></code> | Retrieves a value from tree context if present. Otherwise, would throw an error. |
 | <code><a href="#constructs.Node.lock">lock</a></code> | Locks this construct from allowing more children to be added. |
+| <code><a href="#constructs.Node.removeDependency">removeDependency</a></code> | Remove an ordering dependency on a Dependenable (a construct or set of constructs). |
 | <code><a href="#constructs.Node.setContext">setContext</a></code> | This can be used to set contextual values. |
 | <code><a href="#constructs.Node.tryFindChild">tryFindChild</a></code> | Return a direct child by id, or undefined. |
 | <code><a href="#constructs.Node.tryGetContext">tryGetContext</a></code> | Retrieves a value from tree context. |
@@ -651,9 +652,21 @@ new Node(host: Construct, scope: IConstruct, id: string)
 public addDependency(deps: ...IDependable[]): void
 ```
 
-Add an ordering dependency on another construct.
+Add an ordering dependency on a Dependable (a construct or set of constructs).
 
-An `IDependable`
+It is up to the target document language to decide what an ordering
+relationship means and how it should be rendered; for example, in the AWS
+CDK for CloudFormation it means a dependency from every resource in scope
+of the current construct to every resource in scope of the target set
+of constructs, that get realized as either stack dependencies or
+`DependsOn` relationships in the synthesized template.
+
+`IDependable` is a marker interface that indicates that a class has used
+`Dependable.implement()` to implement the `IDependable` interface. It
+can be used to make the target object represent more than one set of
+constructs at a time. For example, a `DependencyGroup` uses this
+interface to represent an explicit list of 0 or more constructs that should
+be involved in the dependency relationship.
 
 ###### `deps`<sup>Required</sup> <a name="deps" id="constructs.Node.addDependency.parameter.deps"></a>
 
@@ -799,6 +812,23 @@ Locks this construct from allowing more children to be added.
 After this
 call, no more children can be added to this construct or to any children.
 
+##### `removeDependency` <a name="removeDependency" id="constructs.Node.removeDependency"></a>
+
+```typescript
+public removeDependency(deps: ...IDependable[]): void
+```
+
+Remove an ordering dependency on a Dependenable (a construct or set of constructs).
+
+This removes any dependency added using `node.addDependency()`. It must
+use the exact same object that was involved in the `addDependency()` call.
+
+###### `deps`<sup>Required</sup> <a name="deps" id="constructs.Node.removeDependency.parameter.deps"></a>
+
+- *Type:* ...<a href="#constructs.IDependable">IDependable</a>[]
+
+---
+
 ##### `setContext` <a name="setContext" id="constructs.Node.setContext"></a>
 
 ```typescript
@@ -938,7 +968,7 @@ the construct.
 | --- | --- | --- |
 | <code><a href="#constructs.Node.property.addr">addr</a></code> | <code>string</code> | Returns an opaque tree-unique address for this construct. |
 | <code><a href="#constructs.Node.property.children">children</a></code> | <code><a href="#constructs.IConstruct">IConstruct</a>[]</code> | All direct children of this construct. |
-| <code><a href="#constructs.Node.property.dependencies">dependencies</a></code> | <code><a href="#constructs.IConstruct">IConstruct</a>[]</code> | Return all dependencies registered on this node (non-recursive). |
+| <code><a href="#constructs.Node.property.dependencies">dependencies</a></code> | <code><a href="#constructs.IConstruct">IConstruct</a>[]</code> | Constructs that this construct depends on directly. |
 | <code><a href="#constructs.Node.property.id">id</a></code> | <code>string</code> | The id of this construct within the current scope. |
 | <code><a href="#constructs.Node.property.locked">locked</a></code> | <code>boolean</code> | Returns true if this construct or the scopes in which it is defined are locked. |
 | <code><a href="#constructs.Node.property.metadata">metadata</a></code> | <code><a href="#constructs.MetadataEntry">MetadataEntry</a>[]</code> | An immutable array of metadata objects associated with this construct. |
@@ -999,7 +1029,10 @@ public readonly dependencies: IConstruct[];
 
 - *Type:* <a href="#constructs.IConstruct">IConstruct</a>[]
 
-Return all dependencies registered on this node (non-recursive).
+Constructs that this construct depends on directly.
+
+This expands the sets of `Dependables` to the set of `Constructs` that they
+represent.
 
 ---
 

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -364,9 +364,21 @@ export class Node {
   }
 
   /**
-   * Add an ordering dependency on another construct.
+   * Add an ordering dependency on a Dependable (a construct or set of constructs)
    *
-   * An `IDependable`
+   * It is up to the target document language to decide what an ordering
+   * relationship means and how it should be rendered; for example, in the AWS
+   * CDK for CloudFormation it means a dependency from every resource in scope
+   * of the current construct to every resource in scope of the target set
+   * of constructs, that get realized as either stack dependencies or
+   * `DependsOn` relationships in the synthesized template.
+   *
+   * `IDependable` is a marker interface that indicates that a class has used
+   * `Dependable.implement()` to implement the `IDependable` interface. It
+   * can be used to make the target object represent more than one set of
+   * constructs at a time. For example, a `DependencyGroup` uses this
+   * interface to represent an explicit list of 0 or more constructs that should
+   * be involved in the dependency relationship.
    */
   public addDependency(...deps: IDependable[]) {
     if (!this._dependencies) {
@@ -378,7 +390,25 @@ export class Node {
   }
 
   /**
-   * Return all dependencies registered on this node (non-recursive).
+   * Remove an ordering dependency on a Dependenable (a construct or set of constructs)
+   *
+   * This removes any dependency added using `node.addDependency()`. It must
+   * use the exact same object that was involved in the `addDependency()` call.
+   */
+  public removeDependency(...deps: IDependable[]) {
+    if (!this._dependencies) {
+      this._dependencies = new Set();
+    }
+    for (const d of deps) {
+      this._dependencies.delete(d);
+    }
+  }
+
+  /**
+   * Constructs that this construct depends on directly
+   *
+   * This expands the sets of `Dependables` to the set of `Constructs` that they
+   * represent.
    */
   public get dependencies(): IConstruct[] {
     const result = new Array<IConstruct>();

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -521,7 +521,6 @@ describe('defaultChild', () => {
 });
 
 describe('dependencies', () => {
-
   test('addDependency() defines a dependency between two scopes', () => {
     // GIVEN
     const root = new Root();
@@ -552,6 +551,21 @@ describe('dependencies', () => {
 
     // THEN
     expect(consumer.node.dependencies.map(x => x.node.path)).toStrictEqual(['producer']);
+  });
+
+  test('can be removed', () => {
+    // GIVEN
+    const root = new Root();
+    const consumer = new Construct(root, 'consumer');
+    const producer = new Construct(root, 'producer');
+
+
+    // WHEN
+    consumer.node.addDependency(producer);
+    consumer.node.removeDependency(producer);
+
+    // THEN
+    expect(consumer.node.dependencies.map(x => x.node.path)).toStrictEqual([]);
   });
 
   test('DependencyGroup can represent a group of disjoined producers', () => {

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -23,7 +23,11 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Node has `addDependency`, but not `removeDependency`.

I am going to deprecate some dependency removal functions from AWS CDK, because those have been specified way too broadly and operate in a way that will make it hard to guarantee that dependency removal doesn't accidentally remove unintended dependencies.

However, we do need a non-deprecated replacement for that operation, which we will place at the construct tree level.
