### PR TITLE
fix: Node.path takes a lot of time on deep construct trees

### DIFF
--- a/src/construct.ts
+++ b/src/construct.ts
@@ -69,6 +69,7 @@ export class Node {
   private _defaultChild: IConstruct | undefined;
   private _validations: Array<IValidation> | undefined;
   private _addr?: string; // cache
+  private _path?: string; // cache
 
   public constructor(private readonly host: Construct, scope: IConstruct, id: string) {
     id = id ?? ''; // if undefined, convert to empty string
@@ -90,13 +91,16 @@ export class Node {
    * Components are separated by '/'.
    */
   public get path(): string {
-    const components = [];
-    for (const scope of this.scopes) {
-      if (scope.node.id) {
-        components.push(scope.node.id);
+    if (this._path === undefined) {
+      const components = [];
+      for (const scope of this.scopes) {
+        if (scope.node.id) {
+          components.push(scope.node.id);
+        }
       }
+      this._path = components.join(Node.PATH_SEP);
     }
-    return components.join(Node.PATH_SEP);
+    return this._path;
   }
 
   /**

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -61,6 +61,13 @@ export class Node {
    */
   public readonly id: string;
 
+  /**
+   * The full, absolute path of this construct in the tree.
+   *
+   * Components are separated by '/'.
+   */
+  public readonly path: string;
+
   private _locked = false; // if this is "true", addChild will fail
   private _children: { [id: string]: IConstruct } | undefined;
   private _context: { [key: string]: any } | undefined;
@@ -69,7 +76,8 @@ export class Node {
   private _defaultChild: IConstruct | undefined;
   private _validations: Array<IValidation> | undefined;
   private _addr?: string; // cache
-  private _path?: string; // cache
+  private _scopes: readonly IConstruct[];
+
 
   public constructor(private readonly host: Construct, scope: IConstruct, id: string) {
     id = id ?? ''; // if undefined, convert to empty string
@@ -81,26 +89,27 @@ export class Node {
       throw new Error('Only root constructs may have an empty ID');
     }
 
-    // add to parent scope
-    scope?.node.addChild(host, this.id);
+    if (scope) {
+      scope.node.addChild(host, this.id);
+      this.path = scope.node.path ? `${scope.node.path}${Node.PATH_SEP}${this.id}` : this.id;
+      this._scopes = [...scope.node._scopes, this.host];
+    } else {
+      this.path = this.id;
+      this._scopes = [this.host];
+    }
   }
 
   /**
-   * The full, absolute path of this construct in the tree.
+   * All parent scopes of this construct.
    *
-   * Components are separated by '/'.
+   * @returns a list of parent scopes. The last element in the list will always
+   * be the current construct and the first element will be the root of the
+   * tree.
    */
-  public get path(): string {
-    if (this._path === undefined) {
-      const components = [];
-      for (const scope of this.scopes) {
-        if (scope.node.id) {
-          components.push(scope.node.id);
-        }
-      }
-      this._path = components.join(Node.PATH_SEP);
-    }
-    return this._path;
+  public get scopes(): IConstruct[] {
+    // Needs to return a copy to make sure callers can't accidentally mutate
+    // internal state. jsii doesn't support ReadonlyArray.
+    return [...this._scopes];
   }
 
   /**
@@ -120,7 +129,7 @@ export class Node {
    */
   public get addr(): string {
     if (!this._addr) {
-      this._addr = addressOf(this.scopes.map(c => c.node.id));
+      this._addr = addressOf(this._scopes.map(c => c.node.id));
     }
 
     return this._addr;
@@ -265,8 +274,11 @@ export class Node {
    * @returns The context object or an empty object if there is discovered context
    */
   public getAllContext(defaults?: object): any {
-    return this.scopes.reverse()
-      .reduce((a, s) => ({ ...(s.node._context), ...a }), { ...defaults });
+    const ret = { ...defaults };
+    for (const scope of this._scopes) {
+      Object.assign(ret, scope.node._context);
+    }
+    return ret;
   }
 
   /**
@@ -325,30 +337,11 @@ export class Node {
   }
 
   /**
-   * All parent scopes of this construct.
-   *
-   * @returns a list of parent scopes. The last element in the list will always
-   * be the current construct and the first element will be the root of the
-   * tree.
-   */
-  public get scopes(): IConstruct[] {
-    const ret = new Array<IConstruct>();
-
-    let curr: IConstruct | undefined = this.host;
-    while (curr) {
-      ret.unshift(curr);
-      curr = curr.node.scope;
-    }
-
-    return ret;
-  }
-
-  /**
    * Returns the root of the construct tree.
    * @returns The root of the construct tree.
    */
   public get root() {
-    return this.scopes[0];
+    return this._scopes[0];
   }
 
   /**

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -248,25 +248,6 @@ test('if a root construct has a name, it should be included in the path', () => 
   expect(tree.child1_1_1.node.path).toBe('HighChild/Child1/Child11/Child111');
 });
 
-test('construct.path is memoized and not recomputed on subsequent access', () => {
-  const tree = createTree();
-
-  // WHEN: access "path" once so it is computed and cached
-  expect(tree.child1_1_1.node.path).toBe('HighChild/Child1/Child11/Child111');
-  expect(tree.root.node.path).toBe(''); // root path (empty string) is cached too
-
-  // THEN: subsequent accesses return the cached value without walking the scope chain
-  const scopesSpy = jest.spyOn(tree.child1_1_1.node, 'scopes', 'get');
-  expect(tree.child1_1_1.node.path).toBe('HighChild/Child1/Child11/Child111');
-  expect(scopesSpy).not.toHaveBeenCalled();
-  scopesSpy.mockRestore();
-
-  const rootScopesSpy = jest.spyOn(tree.root.node, 'scopes', 'get');
-  expect(tree.root.node.path).toBe('');
-  expect(rootScopesSpy).not.toHaveBeenCalled();
-  rootScopesSpy.mockRestore();
-});
-
 test('construct can not be created with the name of a sibling', () => {
   const root = new Root();
 

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -248,6 +248,25 @@ test('if a root construct has a name, it should be included in the path', () => 
   expect(tree.child1_1_1.node.path).toBe('HighChild/Child1/Child11/Child111');
 });
 
+test('construct.path is memoized and not recomputed on subsequent access', () => {
+  const tree = createTree();
+
+  // WHEN: access "path" once so it is computed and cached
+  expect(tree.child1_1_1.node.path).toBe('HighChild/Child1/Child11/Child111');
+  expect(tree.root.node.path).toBe(''); // root path (empty string) is cached too
+
+  // THEN: subsequent accesses return the cached value without walking the scope chain
+  const scopesSpy = jest.spyOn(tree.child1_1_1.node, 'scopes', 'get');
+  expect(tree.child1_1_1.node.path).toBe('HighChild/Child1/Child11/Child111');
+  expect(scopesSpy).not.toHaveBeenCalled();
+  scopesSpy.mockRestore();
+
+  const rootScopesSpy = jest.spyOn(tree.root.node, 'scopes', 'get');
+  expect(tree.root.node.path).toBe('');
+  expect(rootScopesSpy).not.toHaveBeenCalled();
+  rootScopesSpy.mockRestore();
+});
+
 test('construct can not be created with the name of a sibling', () => {
   const root = new Root();
 


### PR DESCRIPTION
Every construct has a `Node`, and `Node.path` and `Node.scopes` are computed on every access by
walking the full scope chain up to the root and joining the component ids.

These values never change once the construct is created, so we can just eagerly
calculate them instead. The lazy work was predicated on the assumption
that they might only rarely be read, but in practice CDK synthesis reads 
both properties contstantly, and recalculating them incurs a heft cost 
on deep construct trees.

The
most impactful case is the aspect invocation loop in `aws-cdk-lib`
(`invokeAspectsV2`), which recurses the whole tree until it stabilizes and
uses `node.path` as a per-node dedup-map key on every visit. On a large tree
(~5,500 stacks) this was measured at hundreds of millions of `path` reads in a
single synth, dominating both CPU and GC.

This had a pretty nice performance benefit on a CDK package of ours, the synthesis times went from around 15 minutes to 8 minutes.

### Testing

`yarn test` (full jest suite) passes. 
