### PR TITLE
fix: dropping jsii.tsc.outDir breaks Java/Go transliteration for jsii-rosetta consumers

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -109,6 +109,13 @@ project.eslint?.addRules({
   '@typescript-eslint/consistent-type-imports': 'error',
 });
 
+// Restore `jsii.tsc.outDir`/`rootDir` alongside `jsii.tsconfig`
+// See https://github.com/aws/constructs/issues/2879
+project.tryFindObjectFile('package.json')?.addOverride('jsii.tsc', {
+  outDir: 'lib',
+  rootDir: 'src',
+});
+
 // restrict consumers to the package's public API (lib/index.js); this
 // prevents deep imports like `constructs/lib/private/...` from resolving.
 project.package.addField('exports', {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,11 @@
       }
     },
     "tsconfig": "tsconfig.json",
-    "validateTsconfig": "strict"
+    "validateTsconfig": "strict",
+    "tsc": {
+      "outDir": "lib",
+      "rootDir": "src"
+    }
   },
   "exports": {
     ".": {

--- a/test/jsii-tsc.test.ts
+++ b/test/jsii-tsc.test.ts
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Downstream jsii-rosetta consumers need `jsii.tsc.outDir` and `jsii.tsc.rootDir`
+ * to map the shipped `lib/*.d.ts` paths back to the `src/` symbol ids recorded
+ * in the jsii assembly. If these are missing, Java/Go transliteration silently
+ * emits incorrect imports.
+ *
+ * See https://github.com/aws/constructs/issues/2879
+ */
+test('package.json declares jsii.tsc.outDir and rootDir', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+
+  expect(pkg.jsii?.tsc?.outDir).toBe('lib');
+  expect(pkg.jsii?.tsc?.rootDir).toBe('src');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5096,7 +5096,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsii@npm:6.0.x, jsii@npm:~6.0.0":
+"jsii@npm:6.0.x":
+  version: 6.0.9
+  resolution: "jsii@npm:6.0.9"
+  dependencies:
+    "@jsii/check-node": "npm:1.139.0"
+    "@jsii/spec": "npm:1.139.0"
+    case: "npm:^1.6.3"
+    chalk: "npm:^4"
+    fast-deep-equal: "npm:^3.1.3"
+    log4js: "npm:^6.9.1"
+    semver: "npm:^7.8.5"
+    semver-intersect: "npm:^1.5.0"
+    sort-json: "npm:^2.0.1"
+    spdx-license-list: "npm:^6.12.0"
+    typescript: "npm:~6.0"
+    yargs: "npm:^17.7.3"
+  bin:
+    jsii: bin/jsii
+  checksum: 10c0/e8c4ed09dec8b3a79ace3592700a53a07721d8dda87efcf5d4ff37e4115653f6a4c8d4a16f011d7d6554b722710f4bedfef6331a35b54b0d93ebc04d9585fa85
+  languageName: node
+  linkType: hard
+
+"jsii@npm:~6.0.0":
   version: 6.0.7
   resolution: "jsii@npm:6.0.7"
   dependencies:


### PR DESCRIPTION
With 10.8.0 (since deprecated), any tool using jsii-rosetta to transliterate TypeScript that imports `constructs` silently emits broken Java and Go imports: `import constructs.Construct;` instead of `import software.constructs.Construct;`, and a fabricated Go module path. The assembly loads fine and symbol lookup just degrades, so the bad output looks plausible.

10.8.0 replaced `jsii.tsc: { outDir, rootDir }` with `jsii.tsconfig` in package.json. Rosetta needs `jsii.tsc.outDir` to map the shipped `lib/*.d.ts` files back to the `src/` symbol ids in the assembly, and has no fallback for it (aws/jsii-compiler#2740 tracks that gap). This restores the `jsii.tsc` block alongside `jsii.tsconfig`, and adds a test so a future upgrade cannot silently drop it again.

Fixes #2879
